### PR TITLE
Requiring path updated in Example file

### DIFF
--- a/example/index.php
+++ b/example/index.php
@@ -1,19 +1,19 @@
 <?php
-require '../vendor/autoload.php';
+
+$rootDir = str_replace('\\', '/', dirname(__DIR__, 1)) . DIRECTORY_SEPARATOR;
+
+require $rootDir .  'vendor/autoload.php';
 
 use Nahid\JsonQ\Jsonq;
 
 $json=new Jsonq();
-$json->import('../data.json');
-
+$json->import($rootDir . 'data.json');
 
 $result = $json->from('products')
-    ->where('cat', '=', 1)
-    ->fetch()
-    ->sortAs('price', 'desc')
-    ->first();
-            
+                ->where('cat', '=', 1)
+                ->fetch()
+                ->sortAs('price', 'desc')
+                ->first();
 
 echo '<pre>';
 dump($result);
-


### PR DESCRIPTION
If you try to run the following command to test the example file from the root project directory:
`php example/index.php`
you will get an error. 
But if you run the command `php index.php` inside the example folder, it works fine. 
So, I've fixed the directory path issue so that it can be run from any folder hierarchy. 