### PR TITLE
Fixed exception in constructor when using invalid file name

### DIFF
--- a/src/Jsonq.php
+++ b/src/Jsonq.php
@@ -26,13 +26,12 @@ class Jsonq
     {
         if (!is_null($jsonFile)) {
             $path = pathinfo($jsonFile);
-
-            if ($path['extension'] != 'json') {
+            $extansion = isset($path['extension']) ? $path['extension'] : null;
+            
+            if ($extansion != 'json') {
                 throw new InvalidJsonException();
             }
-        }
-
-        if (!is_null($jsonFile) && isset($path['extension'])) {
+            
             $this->import($jsonFile);
         }
     }


### PR DESCRIPTION
Where we use a file without extension as `new Jsonq('data');` then we have not expected behavior. Error 'Notice: Undefined index: extension'. This PR fixed it.