### PR TITLE
Add test for several methods

### DIFF
--- a/src/Jsonq.php
+++ b/src/Jsonq.php
@@ -523,10 +523,10 @@ class Jsonq
      */
     public function json($data)
     {
-        if (is_string($data)) {
-            if ($json = $this->isJson($data, true)) {
-                return $this->collect($json);
-            }
+        $json = $this->isJson($data, true);
+
+        if ($json) {
+            return $this->collect($json);
         }
 
         return $this;

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Nahid\JsonQ\Tests;
+
+abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Make private and protected function callable
+     *
+     * @param mixed $object
+     * @param string $function
+     * @return \ReflectionMethod
+     */
+    protected function makeCallable($object, $function)
+    {
+        $method = new \ReflectionMethod($object, $function);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+}

--- a/tests/JsonQueriableTest.php
+++ b/tests/JsonQueriableTest.php
@@ -5,7 +5,7 @@ namespace Nahid\JsonQ\Tests;
 use Nahid\JsonQ\Jsonq;
 use Nahid\JsonQ\Exceptions\FileNotFoundException;
 
-class JsonQueriableTest extends \PHPUnit_Framework_TestCase
+class JsonQueriableTest extends AbstractTestCase
 {
     const FILE_NAME = 'data.json';
     
@@ -68,6 +68,19 @@ class JsonQueriableTest extends \PHPUnit_Framework_TestCase
         $this->file = null;
     }
     
+    /**
+     * @return \StdClass
+     */
+    private function getTestObject()
+    {
+        $object = new \stdClass();
+        $object->testField = 'test';
+        $object->test_field2 = 'test2';
+        $object->testfield3 = 'test3';
+        
+        return $object;
+    }
+    
     protected function setUp()
     {
         $this->createFile();
@@ -95,6 +108,71 @@ class JsonQueriableTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @param mixed $input
+     * @param mixed $result
+     *
+     * @dataProvider objectToArrayProvider
+     */
+    public function testObjectToArray($input, $result)
+    {
+        $method = $this->makeCallable($this->jsonq, 'objectToArray');
+        
+        $this->assertEquals($result, $method->invokeArgs($this->jsonq, [$input]));
+    }
+    
+    /**
+     * @param mixed $input
+     * @param bool $result
+     *
+     * @dataProvider isMultiArrayProvider
+     */
+    public function testIsMultiArray($input, $result)
+    {
+        $method = $this->makeCallable($this->jsonq, 'isMultiArray');
+        
+        $this->assertEquals($result, $method->invokeArgs($this->jsonq, [$input]));
+    }
+    
+    /**
+     * @param mixed $input
+     * @param bool $isReturnMap
+     * @param mixed $result
+     * 
+     * @dataProvider isJsonProvider
+     */
+    public function testIsJson($input, $isReturnMap, $result = null)
+    {
+        $this->assertEquals($result, $this->jsonq->isJson($input, $isReturnMap));
+    }
+    
+    public function isJsonProvider()
+    {
+        return [
+            [null, false, false], 
+            [true, false, true], 
+            [1, false, true],
+            [new \StdClass(), false, false],
+            [['test'], false, false],
+            ['invalid_json_string', false, false],
+            [json_encode('valid_json_string'), false, true],
+            [json_encode('valid_json_string'), true, 'valid_json_string']
+        ];
+    }
+    
+    public function isMultiArrayProvider()
+    {
+        return [
+            [null, false], 
+            [true, false], 
+            [1, false], 
+            ['test', false],
+            [['test', 'test'], false],
+            [['test',['test']], true],
+            [[['test'], 'test'], true]
+        ];
+    }
+    
     public function importProvider()
     {
         return [
@@ -103,6 +181,18 @@ class JsonQueriableTest extends \PHPUnit_Framework_TestCase
             [true, false], 
             [1, false], 
             ['invalid_path.json', false]
+        ];
+    }
+    
+    public function objectToArrayProvider()
+    {
+        return [
+            [null, null], 
+            [true, true], 
+            [1, 1], 
+            ['test', 'test'],
+            [['data1', 'data2'],['data1', 'data2']],
+            [$this->getTestObject(), ['testField' => 'test', 'test_field2' => 'test2', 'testfield3' => 'test3']]
         ];
     }
 }


### PR DESCRIPTION
1) Tests for methods of JsonQueryable trait:
 - objectToArray
 - isMultiArray
 - isJson

2) Modify annotations and parameter names according PSR
3) Changed logic in `isJson` method and in related methods.
 - method must obviously return `false` when json_decode getting error, because from the method name follows, that it check is valid input `json string` or not. If developer wants to know what error at his `json string` he just debug it (it not the task of current method).
- in method we need obviously check the input data is not the array or object, because `json_decode` does not accept them as an argument
- removed checking `is_string($data)` before call `isJson` method, because this is not necessary, since `json_decode` function perfectly handles other types of data (except array and object, which we check in the method inside)


