### PR TITLE
Add unnecessary files/folders to export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 /.gitignore export-ignore
 /README.md export-ignore
 /examples export-ignore
+/tests export-ignore
+/phpunit.xml.dist	export-ignore
+/.travis.yml export-ignore


### PR DESCRIPTION
`/tests`, `/phpunit.xml.dist`, and `/.travis.yml` aren't needed when pulling down the package via Composer, so we can add them to the `export-ignore` list to prevent them from being downloaded.