### PR TITLE
Refactoring condition

### DIFF
--- a/src/Condition.php
+++ b/src/Condition.php
@@ -64,7 +64,7 @@ class Condition
      *
      * @return bool
      */
-    public static function greater($value, $comparable)
+    public static function greaterThan($value, $comparable)
     {
         return $value > $comparable;
     }
@@ -77,7 +77,7 @@ class Condition
      * 
      * @return bool
      */
-    public static function condLess($value, $comparable)
+    public static function lessThan($value, $comparable)
     {
         return $value < $comparable;
     }
@@ -90,7 +90,7 @@ class Condition
      *
      * @return bool
      */
-    public static function greaterEqual($value, $comparable)
+    public static function greaterThanOrEqual($value, $comparable)
     {
         return $value >= $comparable;
     }
@@ -103,7 +103,7 @@ class Condition
      *
      * @return bool
      */
-    public static function lessEqual($value, $comparable)
+    public static function lessThanOrEqual($value, $comparable)
     {
         return $value <= $comparable;
     }

--- a/src/Condition.php
+++ b/src/Condition.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Nahid\JsonQ;
+
+class Condition
+{
+    /**
+     * Simple equals
+     *
+     * @param mixed $value
+     * @param mixed $comparable
+     *
+     * @return bool
+     */
+    public static function equal($value, $comparable)
+    {
+        return $value == $comparable;
+    }
+
+    /**
+     * Strict equals
+     *
+     * @param mixed $value
+     * @param mixed $comparable
+     *
+     * @return bool
+     */
+    public static function strictEqual($value, $comparable)
+    {
+        return $value === $comparable;
+    }
+
+    /**
+     * Simple not equal
+     *
+     * @param mixed $value
+     * @param mixed $comparable
+     *
+     * @return bool
+     */
+    public static function notEqual($value, $comparable)
+    {
+        return $value != $comparable;
+    }
+
+    /**
+     * Strict not equal
+     *
+     * @param mixed $value
+     * @param mixed $comparable
+     *
+     * @return bool
+     */
+    public static function notExactEqual($value, $comparable)
+    {
+        return $value !== $comparable;
+    }
+
+    /**
+     * Strict greater than
+     *
+     * @param mixed $value
+     * @param mixed $comparable
+     *
+     * @return bool
+     */
+    public static function greater($value, $comparable)
+    {
+        return $value > $comparable;
+    }
+
+    /**
+     * Strict less than
+     *
+     * @param mixed $value
+     * @param mixed $comparable
+     * 
+     * @return bool
+     */
+    public static function condLess($value, $comparable)
+    {
+        return $value < $comparable;
+    }
+
+    /**
+     * Greater or equal
+     *
+     * @param mixed $value
+     * @param mixed $comparable
+     *
+     * @return bool
+     */
+    public static function greaterEqual($value, $comparable)
+    {
+        return $value >= $comparable;
+    }
+
+    /**
+     * Less or equal
+     *
+     * @param mixed $value
+     * @param mixed $comparable
+     *
+     * @return bool
+     */
+    public static function lessEqual($value, $comparable)
+    {
+        return $value <= $comparable;
+    }
+
+    /**
+     * In array
+     *
+     * @param mixed $value
+     * @param array $comparable
+     *
+     * @return bool
+     */
+    public static function in($value, $comparable)
+    {
+        return (is_array($comparable) && in_array($value, $comparable));
+    }
+
+    /**
+     * Not in array
+     *
+     * @param mixed $value
+     * @param array $comparable
+     *
+     * @return bool
+     */
+    public static function notIn($value, $comparable)
+    {
+        return (is_array($comparable) && !in_array($value, $comparable));
+    }
+
+    /**
+     * Is null equal
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public static function isNull($value)
+    {
+        return is_null($value);
+    }
+
+    /**
+     * Is not null equal
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public static function isNotNull($value)
+    {
+        return !is_null($value);
+    }
+
+    /**
+     * Start With
+     *
+     * @param mixed $value
+     * @param string $comparable
+     *
+     * @return bool
+     */
+    public static function startWith($value, $comparable)
+    {
+        if (preg_match("/^$comparable/", $value)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * End with
+     *
+     * @param mixed $value
+     * @param string $comparable
+     *
+     * @return bool
+     */
+    public static function endWith($value, $comparable)
+    {
+        if (preg_match("/$comparable$/", $value)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Match with pattern
+     *
+     * @param mixed $value
+     * @param string $comparable
+     *
+     * @return bool
+     */
+    public static function match($value, $comparable)
+    {
+        $comparable = trim($comparable);
+
+        if (preg_match("/^$comparable$/", $value)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Contains substring in string
+     *
+     * @param string $value
+     * @param string $comparable
+     *
+     * @return bool
+     */
+    public static function contains($value, $comparable)
+    {
+        return (strpos($value, $comparable) !== false);
+    }
+
+    /**
+     * Dates equal
+     *
+     * @param string $value
+     * @param string $comparable
+     *
+     * @return bool
+     */
+    public static function dateEqual($value, $comparable, $format = 'Y-m-d')
+    {
+        $date = date($format, strtotime($value));
+        return $date == $comparable;
+    }
+
+    /**
+     * Months equal
+     *
+     * @param string $value
+     * @param string $comparable
+     *
+     * @return bool
+     */
+    public static function monthEqual($value, $comparable)
+    {
+        $month = date('m', strtotime($value));
+        return $month == $comparable;
+    }
+
+    /**
+     * Years equal
+     *
+     * @param string $value
+     * @param string $comparable
+     *
+     * @return bool
+     */
+    public static function yearEqual($value, $comparable)
+    {
+        $year = date('Y', strtotime($value));
+        return $year == $comparable;
+    }
+}

--- a/src/JsonQueriable.php
+++ b/src/JsonQueriable.php
@@ -53,14 +53,14 @@ trait JsonQueriable
         'neq' => 'notEqual',
         '!==' => 'strictNotEqual',
         'sneq' => 'strictNotEqual',
-        '>' => 'greater',
-        'gt' => 'greater',
-        '<' => 'less',
-        'lt' => 'less',
-        '>=' => 'greaterEqual',
-        'gte' => 'greaterEqual',
-        '<=' => 'lessEqual',
-        'lte' => 'lessEqual',
+        '>' => 'greaterThan',
+        'gt' => 'greaterThan',
+        '<' => 'lessThan',
+        'lt' => 'lessThan',
+        '>=' => 'greaterThanOrEqual',
+        'gte' => 'greaterThanOrEqual',
+        '<=' => 'lessThanOrEqual',
+        'lte' => 'lessThanOrEqual',
         'in'    => 'in',
         'notin' => 'notIn',
         'null' => 'isNull',
@@ -249,7 +249,7 @@ trait JsonQueriable
         if (empty($this->_node) || $this->_node == '.') {
             return $this->_map;
         }
-        
+
         if ($this->_node) {
             $terminate = false;
             $map = $this->_map;


### PR DESCRIPTION
1) Moved conditions in a separate class to avoid swelling `JsonQueryable` trait and to get rid of the prefix `cond` for condition methods.
2) Made more readable `processConditions` function. Without logic change.