### PR TITLE
Added ValueNotFound object

### DIFF
--- a/src/JsonQueriable.php
+++ b/src/JsonQueriable.php
@@ -5,6 +5,7 @@ namespace Nahid\JsonQ;
 use Nahid\JsonQ\Exceptions\ConditionNotAllowedException;
 use Nahid\JsonQ\Exceptions\FileNotFoundException;
 use Nahid\JsonQ\Exceptions\InvalidJsonException;
+use Nahid\JsonQ\Results\ValueNotFound;
 use Nahid\JsonQ\Condition;
 
 trait JsonQueriable
@@ -339,13 +340,13 @@ trait JsonQueriable
             }
 
             if ($terminate) {
-                return false;
+                return new ValueNotFound();
             }
 
             return $map;
         }
 
-        return false;
+        return new ValueNotFound();
     }
 
     /**
@@ -383,7 +384,7 @@ trait JsonQueriable
                     }
                     
                     $value = $this->getFromNested($val, $rule['key']);
-                    $return = $value === null || $value !== '' ? call_user_func_array($function, [$value, $rule['value']]) : false;
+                    $return = $value instanceof ValueNotFound ? false :  call_user_func_array($function, [$value, $rule['value']]);
                     $tmp &= $return;
                 }
                 $res |= $tmp;

--- a/src/Results/ValueNotFound.php
+++ b/src/Results/ValueNotFound.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Nahid\JsonQ\Results;
+
+/**
+ * This class represents a query result where a given
+ * value was queried but did not exist.
+ */
+class ValueNotFound {}

--- a/tests/JsonQueriableTest.php
+++ b/tests/JsonQueriableTest.php
@@ -5,6 +5,7 @@ namespace Nahid\JsonQ\Tests;
 use Nahid\JsonQ\Jsonq;
 use Nahid\JsonQ\Exceptions\FileNotFoundException;
 use Nahid\JsonQ\Exceptions\InvalidJsonException;
+use Nahid\JsonQ\Results\ValueNotFound;
 
 class JsonQueriableTest extends AbstractTestCase
 {
@@ -59,6 +60,18 @@ class JsonQueriableTest extends AbstractTestCase
                 'level3.16' => 'data316',
                 'level3.17' => 317,
                 'level3.18' => true,
+            ]
+        ]
+    ];
+
+    protected static $testDataNesting = [
+        'level1' => [
+            'level2' => [
+                'level3-1' => 'data31',
+                'level3-2' => 32,
+                'level3-3' => false,
+                'level3-4' => null,
+                'level3-5' => '',
             ]
         ]
     ];
@@ -193,6 +206,39 @@ class JsonQueriableTest extends AbstractTestCase
         }
     }
     
+    /**
+     * @param mixed $path
+     * @param mixed $expected
+     *
+     * @dataProvider getFromNestedProvider
+     */
+    public function testGetFromNested($path, $expected)
+    {
+        $method = $this->makeCallable($this->jsonq, 'getFromNested');
+        
+        $input = [self::$testDataNesting, $path];
+
+        $result = $method->invokeArgs($this->jsonq, $input);
+
+        if ($result instanceof ValueNotFound) {
+            $result = ValueNotFound::class;
+        }
+
+        $this->assertEquals($expected, $result);
+    }
+    
+    public function getFromNestedProvider()
+    {
+        return [
+            ['level1.level2.level3-1', 'data31'], 
+            ['level1.level2.level3-2', 32], 
+            ['level1.level2.level3-3', false], 
+            ['level1.level2.level3-4', null], 
+            ['level1.level2.level3-5', ''], 
+            ['level1.level2.not-existing', ValueNotFound::class], 
+        ];
+    }    
+
     public function getDataFromFileProvider()
     {
         return [


### PR DESCRIPTION
If a value is queried it is possible that the value is `null`, `''` or `false`.
These are all valid return values that the user might want to know about.

With the current default return value of `false` in the `getFromNested` method, a custom macro might be called with `false` as a value (but in this case the value does not exist). Empty strings on the other hand are never passed to the macro but the user might care about these.

To distinct these falsey values from a value that was effectifely not found, the `ValueNotFound` object was introduced in this commit.

