### PR TITLE
Added sortByCallable method

### DIFF
--- a/src/Jsonq.php
+++ b/src/Jsonq.php
@@ -436,6 +436,27 @@ class Jsonq
     }
 
     /**
+     * Sort prepared data using a custom sort function.
+     *
+     * @param callable $sortFunc
+     *
+     * @return object|array|null
+     * @throws ConditionNotAllowedException
+     */
+    public function sortByCallable(callable $sortFunc)
+    {
+        $this->prepare();
+
+        if (!is_array($this->_map)) {
+            return $this;
+        }
+
+        usort($this->_map, $sortFunc);
+
+        return $this;
+    }
+
+    /**
      * Sort an array value
      *
      * @param string $order


### PR DESCRIPTION
Sometimes more control over sorting is needed than the two `column` and `direction` parameters. 

This PR adds a `sortByCallable` method that allows a user to specify a custom sort function.

I need this specific case to implement a `sort by random` functionality.

```php
$sortRandom = function($a, $b) {
   return random_int(-1, 1);
}
$jsonq->sortByCallable($sortRandom);
```