### PR TITLE
Allow grouping by a column that has a value of "0"

### DIFF
--- a/src/Jsonq.php
+++ b/src/Jsonq.php
@@ -6,6 +6,7 @@ use Nahid\JsonQ\Exceptions\ConditionNotAllowedException;
 use Nahid\JsonQ\Exceptions\InvalidJsonException;
 use Nahid\JsonQ\Exceptions\InvalidNodeException;
 use Nahid\JsonQ\Exceptions\NullValueException;
+use Nahid\JsonQ\Results\ValueNotFound;
 
 class Jsonq
 {
@@ -187,7 +188,7 @@ class Jsonq
         $data = [];
         foreach ($this->_map as $map) {
             $value = $this->getFromNested($map, $column);
-            if ($value) {
+            if (!$value instanceof ValueNotFound) {
                 $data[$value][] = $map;
             }
         }


### PR DESCRIPTION
Having this data:

```json
[
    {
        "name": "testA",
        "code": "0"
    },
    {
        "name": "testB",
        "code": "0"
    },
    {
        "name": "testC",
        "code": "1"
    }
]
```
When grouping by code, 
the items with code '0' were not returned because the if statement evaluated them as false.